### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.6.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.5.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Each element of the above can be independently overridden using the "connection_
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Usage considerations
 ### API Versions
 API versions use different variable names. One known api variation is "hostname". This is used within the buildplan assignment api call.

--- a/actions/icsp_buildplan_apply.yaml
+++ b/actions/icsp_buildplan_apply.yaml
@@ -1,6 +1,6 @@
 ---
   name: "icsp_buildplan_apply"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Apply Buidlplan to Specified Servers"
   enabled: true
   entry_point: "icsp_buildplan_apply.py"

--- a/actions/icsp_buildplan_get.yaml
+++ b/actions/icsp_buildplan_get.yaml
@@ -1,6 +1,6 @@
 ---
   name: "icsp_buildplan_get"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Retreive Available BuildPlans"
   enabled: true
   entry_point: "icsp_buildplan_get.py"

--- a/actions/icsp_ca_get.yaml
+++ b/actions/icsp_ca_get.yaml
@@ -1,6 +1,6 @@
 ---
   name: "icsp_ca_get"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Retreive CA Certificate from ICSP"
   enabled: true
   entry_point: "icsp_ca_get.py"

--- a/actions/icsp_job_status_get.yaml
+++ b/actions/icsp_job_status_get.yaml
@@ -1,6 +1,6 @@
 ---
   name: "icsp_job_status_get"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Return Status of specified Job"
   enabled: true
   entry_point: "icsp_job_status_get.py"

--- a/actions/icsp_mid_get.yaml
+++ b/actions/icsp_mid_get.yaml
@@ -1,6 +1,6 @@
 ---
   name: "icsp_mid_get"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Retreive MIDs for specified servers."
   enabled: true
   entry_point: "icsp_mid_get.py"

--- a/actions/icsp_server_attribute_add.yaml
+++ b/actions/icsp_server_attribute_add.yaml
@@ -1,6 +1,6 @@
 ---
   name: "icsp_server_attribute_add"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Add or Update a Server attribute on a ICSP registered server."
   enabled: true
   entry_point: "icsp_server_attribute_set.py"

--- a/actions/icsp_server_attribute_del.yaml
+++ b/actions/icsp_server_attribute_del.yaml
@@ -1,6 +1,6 @@
 ---
   name: "icsp_server_attribute_del"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Remove a Server attribute on a ICSP registered server."
   enabled: true
   entry_point: "icsp_server_attribute_set.py"

--- a/actions/icsp_server_attributes_get.yaml
+++ b/actions/icsp_server_attributes_get.yaml
@@ -1,6 +1,6 @@
 ---
   name: "icsp_server_attributes_get"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Retrieve Attributes set against Server"
   enabled: true
   entry_point: "icsp_server_attributes_get.py"

--- a/actions/icsp_server_data_format.yaml
+++ b/actions/icsp_server_data_format.yaml
@@ -1,6 +1,6 @@
 ---
   name: "icsp_server_data_format"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Generate Server Data Input for bulidplan apply action. MID and Hostname arrays must contain the same number of values. Option values of domain and workgroup can be provided but will be ignored if element count differs from MID count."
   enabled: true
   entry_point: "icsp_server_data_format.py"

--- a/actions/icsp_server_delete.yaml
+++ b/actions/icsp_server_delete.yaml
@@ -1,6 +1,6 @@
 ---
   name: "icsp_server_delete"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Delete server from ICSP server list."
   enabled: true
   entry_point: "icsp_server_delete.py"

--- a/actions/icsp_server_details_get.yaml
+++ b/actions/icsp_server_details_get.yaml
@@ -1,6 +1,6 @@
 ---
   name: "icsp_server_details_get"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Retrieve details for specified server"
   enabled: true
   entry_point: "icsp_server_details_get.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: hpe_icsp
 name : hpe_icsp
 description : Pack for HP Enterprise Insight Control Server Provisioning Integration
-version : 0.5.0
+version : 0.6.0
 author : Paul Mulvihill
 email : paul.mulvihill@pulsant.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.