### PR TITLE
ICSP get servers action and update to server delete action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 # 0.6.1
 
 - Addition of of get servers action to list current registered servers
+- Update to delete server action to take three types of identifier
 
 # 0.6.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.6.1
+
+- Addition of of get servers action to list current registered servers
+
 # 0.6.0
 
 - Updated action `runner_type` from `run-python` to `python-script`

--- a/actions/icsp_server_delete.py
+++ b/actions/icsp_server_delete.py
@@ -17,9 +17,14 @@ from lib.icsp import ICSPBaseActions
 
 
 class DeleteServer(ICSPBaseActions):
-    def run(self, mids, connection_details=None):
+    def run(self, identifiers, id_type, connection_details=None):
         self.set_connection(connection_details)
         self.get_sessionid()
+        if id_type != "mids":
+            mids = self.get_mids(identifiers, id_type)
+        else:
+            mids = identifiers
+
         for mid in mids:
             try:
                 isinstance(mid, int)

--- a/actions/icsp_server_delete.yaml
+++ b/actions/icsp_server_delete.yaml
@@ -5,14 +5,23 @@
   enabled: true
   entry_point: "icsp_server_delete.py"
   parameters:
-    mids:
+    identifiers:
       type: "array"
-      description: "Server MID list."
+      description: "Server idenfiter list list."
       required: true
       position: 0
+    id_type:
+      type: "string"
+      description: "Type of Identifier used."
+      required: true
+      position: 1
+      enum:
+        - mids
+        - serialnumber
+        - uuid
     connection_details:
       type: "object"
       description: "Connection details. eg { \"host\": \"192.168.0.1\", \"user\":\"username\", \"pass\": \"secret\" }"
       required: false
       secret: true
-      position: 1
+      position: 2

--- a/actions/icsp_servers_get.py
+++ b/actions/icsp_servers_get.py
@@ -31,5 +31,4 @@ class GetServers(ICSPBaseActions):
             elif server['state'] == state:
                 results.append(server)
 
-
         return results

--- a/actions/icsp_servers_get.py
+++ b/actions/icsp_servers_get.py
@@ -17,20 +17,19 @@ from lib.icsp import ICSPBaseActions
 
 
 class GetServers(ICSPBaseActions):
-    def run(self, connection_details=None):
-
+    def run(self, state, connection_details=None):
+        results = []
         self.set_connection(connection_details)
         self.get_sessionid()
-        servers = self.get_servers()
+        endpoint = "/rest/os-deployment-servers/"
+        allservers = self.icsp_get(endpoint)
+        filters = allservers['members']
 
-        if servers:
-            list = {}
-            for server in servers:
-                serialNumber = server['serialNumber']
-                print serialNumber
-                if server['serialNumber'] is not None:
-                    list[serialNumber] = server
-            return list
-          
-        else:
-            raise ValueError("No Servers Found")
+        for server in filters:
+            if state == "ALL":
+                results.append(server)
+            elif server['state'] == state:
+                results.append(server)
+
+
+        return results

--- a/actions/icsp_servers_get.py
+++ b/actions/icsp_servers_get.py
@@ -1,0 +1,36 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lib.icsp import ICSPBaseActions
+
+
+class GetServers(ICSPBaseActions):
+    def run(self, connection_details=None):
+
+        self.set_connection(connection_details)
+        self.get_sessionid()
+        servers = self.get_servers()
+
+        if servers:
+            list = {}
+            for server in servers:
+                serialNumber = server['serialNumber']
+                print serialNumber
+                if server['serialNumber'] is not None:
+                    list[serialNumber] = server
+            return list
+          
+        else:
+            raise ValueError("No Servers Found")

--- a/actions/icsp_servers_get.yaml
+++ b/actions/icsp_servers_get.yaml
@@ -1,13 +1,24 @@
 ---
   name: "icsp_servers_get"
-  runner_type: "run-python"
-  description: "Retreive servers currently registered against the ICSP server."
+  runner_type: "python-script"
+  description: "Retrieve Servers registered in ICSP"
   enabled: true
   entry_point: "icsp_servers_get.py"
   parameters:
+    state:
+      type: "string"
+      description: "Return servers of this state"
+      required: false
+      position: 0
+      default: all
+      enum:
+        - ALL
+        - OK
+        - MAINTENANCE
+        - UNREACHABLE
     connection_details:
       type: "object"
       description: "Connection details. eg { \"host\": \"192.168.0.1\", \"user\":\"username\", \"pass\": \"secret\" }"
       required: false
       secret: true
-      position: 2
+      position: 3

--- a/actions/icsp_servers_get.yaml
+++ b/actions/icsp_servers_get.yaml
@@ -21,4 +21,4 @@
       description: "Connection details. eg { \"host\": \"192.168.0.1\", \"user\":\"username\", \"pass\": \"secret\" }"
       required: false
       secret: true
-      position: 3
+      position: 1

--- a/actions/icsp_servers_get.yaml
+++ b/actions/icsp_servers_get.yaml
@@ -1,0 +1,13 @@
+---
+  name: "icsp_servers_get"
+  runner_type: "run-python"
+  description: "Retreive servers currently registered against the ICSP server."
+  enabled: true
+  entry_point: "icsp_servers_get.py"
+  parameters:
+    connection_details:
+      type: "object"
+      description: "Connection details. eg { \"host\": \"192.168.0.1\", \"user\":\"username\", \"pass\": \"secret\" }"
+      required: false
+      secret: true
+      position: 2

--- a/actions/lib/icsp.py
+++ b/actions/lib/icsp.py
@@ -88,12 +88,6 @@ class ICSPBaseActions(Action):
                                 mids.append(int(server["mid"]))
         return mids
 
-    def get_servers(self):
-        endpoint = "/rest/os-deployment-servers"
-        getresults = self.icsp_get(endpoint)
-        servers = getresults["members"]
-        return servers
-
     def validate_mids(self, identifiers):
         for n in identifiers:
             try:

--- a/actions/lib/icsp.py
+++ b/actions/lib/icsp.py
@@ -88,6 +88,12 @@ class ICSPBaseActions(Action):
                                 mids.append(int(server["mid"]))
         return mids
 
+    def get_servers(self):
+        endpoint = "/rest/os-deployment-servers"
+        getresults = self.icsp_get(endpoint)
+        servers = getresults["members"]
+        return servers
+
     def validate_mids(self, identifiers):
         for n in identifiers:
             try:

--- a/pack.yaml
+++ b/pack.yaml
@@ -2,6 +2,6 @@
 ref: hpe_icsp
 name : hpe_icsp
 description : Pack for HP Enterprise Insight Control Server Provisioning Integration
-version : 0.6.0
+version : 0.6.1
 author : Paul Mulvihill
 email : paul.mulvihill@pulsant.com


### PR DESCRIPTION
Introduce action to return the list of servers currently registered against a ICSP server. in the supported states.
Update to server delete action to take in mids, serial numbers or UUID for server identification